### PR TITLE
Restore pymupdf dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ memory-tempfile
 docker
 git+https://github.com/phfaist/pylatexenc.git
 spacy
-#pymupdf
+pymupdf
 pdfplumber
 pandas
 docker


### PR DESCRIPTION
I believe that `pymupdf` is still required to run this project code as shown. `main.py` depends on `fitz` which is party of `pymupdf` : https://github.com/InsightsNet/texannotate/blob/main/main.py#L4 
Installing this makes it work fine.